### PR TITLE
Tidal Single mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,25 @@ Alternatively you can start Troop in a different "mode" so that it is interpreti
 
 	python run-client.py --mode TidalCyclesStack
 
+**TidalCycles single mode**
+
+The idea of this mode is that only one client, the master, actually starts TidalCycles and executes commands against it. All other client just send commands and receive the output from the master. This is different form the normal TidalCycles mode in which all clients start their own TidalCycles session and execute all commands sent to them. This mode is useful for example if all participants are playing on the same sound system.
+
+```shell
+python run-client.py --mode tidalcycles-single-master              # start the master client
+python run-client.py --mode tidalcycles-single                     # start the first normal client
+python run-client.py --mode tidalcycles-single                     # start the second normal client
+```
+
+You usually only want one master to be started at any one time but you can start multiple masters. In this case you might want to supply the `silent` argument to all but one master to avoid duplication of Tidal output in the console:
+
+```shell
+python run-client.py --mode tidalcycles-single-master              # start the first master client
+python run-client.py --mode tidalcycles-single-master -a silent    # start the second master client but suppress output
+python run-client.py --mode tidalcycles-single                     # start the first normal client
+python run-client.py --mode tidalcycles-single                     # start the second normal client
+```
+
 **[SuperCollider](https://supercollider.github.io/)**
 
 	python run-client.py --mode SuperCollider

--- a/run-client.py
+++ b/run-client.py
@@ -24,6 +24,7 @@
 """
 
 import argparse
+from src.config import langnames
 
 parser = argparse.ArgumentParser(
     prog="Troop Client", 
@@ -34,7 +35,7 @@ parser.add_argument('-p', '--public', action='store_true', help="Connect to publ
 parser.add_argument('-H', '--host', action='store', help="IP Address of the machine running the Troop server")#, default="localhost")
 parser.add_argument('-P', '--port', action='store', help="Port for Troop server (default 57890)")#, default=57890)
 parser.add_argument('-m', '--mode', action='store', default='foxdot',
-                    help='Name of live coding language (TidalCycles, SonicPi, SuperCollider, FoxDot, None, or a valid executable')
+                    help='Name of live coding language ('+", ".join(langnames.keys())+') or a valid executable')
 parser.add_argument('-a', '--args', action='store', help="Add extra arguments to supply to the interpreter", nargs=argparse.REMAINDER, type=str)
 parser.add_argument('-c', '--config', action='store_true', help="Load connection info from 'client.cfg'")
 parser.add_argument('-l', '--log', action='store_true')

--- a/src/client.py
+++ b/src/client.py
@@ -105,6 +105,8 @@ class Client:
 
             self.lang = DummyInterpreter()
 
+        self.lang.sender = self.send_from_here
+
         # Create address book
 
         self.peers = {}
@@ -124,7 +126,10 @@ class Client:
         self.send.ui = self.ui
 
         self.ui.run()
-
+    
+    def send_from_here(self, msg_type, *args, **kwargs):
+        msg_cls = MESSAGE_TYPE[msg_type]
+        self.send(msg_cls(self.id, *args, **kwargs))
 
     @staticmethod
     def read_configuration_file(filename):

--- a/src/config.py
+++ b/src/config.py
@@ -112,12 +112,16 @@ TIDAL         = 1
 TIDALSTACK    = 2
 SUPERCOLLIDER = 3
 SONICPI       = 4
+TIDALSINGLEM  = 5
+TIDALSINGLE   = 6
 
 langnames = { "foxdot"           : FOXDOT,
               "tidalcycles"      : TIDAL,
               "tidalcyclesstack" : TIDALSTACK,
               "supercollider"    : SUPERCOLLIDER,
               "sonic-pi"         : SONICPI,
+              "tidalcycles-single-master" : TIDALSINGLEM,
+              "tidalcycles-single"        : TIDALSINGLE,
               "none"             : DUMMY }
 
 langtitles = { "foxdot"           : "FoxDot",
@@ -125,6 +129,8 @@ langtitles = { "foxdot"           : "FoxDot",
                "supercollider"    : "SuperCollider",
                "tidalcyclesstack" : "TidalCycles (stack)",
                "sonic-pi"         : "Sonic-Pi",
+               "tidalcycles-single-master" : "TidalCycles (single, master)",
+               "tidalcycles-single"        : "TidalCycles (single)",
                "none"             : "No Interpreter" }
 
 def getInterpreter(path):

--- a/src/interface/textbox.py
+++ b/src/interface/textbox.py
@@ -66,6 +66,7 @@ class ThreadSafeText(Text, OTClient):
         self.add_handle(MSG_SELECT,             self.handle_select)
         self.add_handle(MSG_EVALUATE_BLOCK,     self.handle_evaluate)
         self.add_handle(MSG_EVALUATE_STRING,    self.handle_evaluate_str)
+        self.add_handle(MSG_CONSOLE_OUT,        self.handle_console_out)
         self.add_handle(MSG_REMOVE,             self.handle_remove)
         self.add_handle(MSG_KILL,               self.handle_kill)
         self.add_handle(MSG_SET_ALL,            self.handle_set_all)
@@ -376,6 +377,13 @@ class ThreadSafeText(Text, OTClient):
         peer = self.get_peer(message)
 
         self.root.lang.evaluate(message["string"], name=str(peer), colour=peer.bg)
+
+        return
+
+    def handle_console_out(self, message):
+        """ Adds the text to the console """
+        
+        self.root.lang.write_console(message["text"])
 
         return
 

--- a/src/message.py
+++ b/src/message.py
@@ -285,8 +285,12 @@ class MSG_CONSTRAINT(MESSAGE):
         self['constraint_id'] = int(constraint_id) 
         # self.peer_id = int(peer) # 
 
-
-
+class MSG_CONSOLE_OUT(MESSAGE):
+    """ The contens of this message should be displayed in the console. """
+    type = 16
+    def __init__(self, src_id, text):
+        MESSAGE.__init__(self, src_id)
+        self['text'] = text
  
 # Create a dictionary of message type to message class 
 
@@ -302,6 +306,7 @@ MESSAGE_TYPE = {msg.type : msg for msg in [
         MSG_KILL,
         MSG_EVALUATE_BLOCK,
         MSG_EVALUATE_STRING,
+        MSG_CONSOLE_OUT,
         MSG_RESET,
         MSG_CONNECT_ACK,
         MSG_REQUEST_ACK,


### PR DESCRIPTION
Hi,

when locally collaborating (e.g. all people are in the same room) it's sometimes desirable to all work with the same instance of Tidal. While a similar effect could be achieved by muting all but one Troop client, there is still the possibility of differing Tidal and Haskell setups per client, so even if they execute the same commands, they might get different results.

This branch adds a Tidal Single mode, in which one master client starts a Tidal instance and the other clients just send commands to it and receive output from it. This in essence creates a shared Tidal session. It is possible to start two master clients, for example if you'd like to play jointly in two distant locations.

Let me know what you think about this. I'm happy to make changes if necessary.

Cheers, @oscons